### PR TITLE
feat: add hint for re-authorize

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -13,7 +13,7 @@ import {
   MastodonError,
   Notification,
 } from "./types";
-import { client } from "./oauth";
+import { client, permissionScope } from "./oauth";
 
 const CONFIG = {
   tokenUrl: "/oauth/token",
@@ -82,8 +82,7 @@ const createApp = async (): Promise<Credentials> =>
   requestApi<Credentials>("POST", CONFIG.appUrl, {
     client_name: "Raycast - Mastodon",
     redirect_uris: "https://raycast.com/redirect?packageName=Extension",
-    scopes:
-      "read:statuses read:bookmarks read:accounts read:favourites read:notifications write:favourites write:media write:bookmarks write:statuses write:notifications",
+    scopes: permissionScope,
     website: "https://raycast.com/SevicheCC/mastodon",
   });
 

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -9,6 +9,19 @@ export const client = new OAuth.PKCEClient({
   description: "Connect to your Mastodon account",
 });
 
+export const permissionScope = [
+  "read:statuses",
+  "read:bookmarks",
+  "read:accounts",
+  "read:favourites",
+  "read:notifications",
+  "write:favourites",
+  "write:media",
+  "write:bookmarks",
+  "write:statuses",
+  "write:notifications",
+].join(" ");
+
 const requestAccessToken = async (
   clientId: string,
   clientSecret: string,
@@ -65,8 +78,7 @@ const authorize = async (): Promise<string> => {
   const authRequest = await client.authorizationRequest({
     endpoint: `https://${instance}/oauth/authorize`,
     clientId: client_id,
-    scope:
-      "read:statuses read:bookmarks read:accounts read:favourites read:notifications write:favourites write:media write:bookmarks write:statuses write:notifications",
+    scope: permissionScope,
   });
 
   const { authorizationCode } = await client.authorize(authRequest);


### PR DESCRIPTION
It will show a prompt to use a deeplink to launch the `menu-bar-notifications` command again.

### Preview

![](https://github.com/Sevichecc/raycast-mastodon-extension/assets/8186898/51184bd8-95bb-475b-95d1-3a9ceac4ec53)